### PR TITLE
Add `metadata` to `createInstance`

### DIFF
--- a/lib/endpoints/workflow-instances.js
+++ b/lib/endpoints/workflow-instances.js
@@ -87,6 +87,12 @@ const endpoint = (client) => ({
     if (opts.documentDelivery) {
       form.append('document_delivery', 'true');
     }
+    
+    if(opts.metadata) {
+      Object.entries(opts.metadata).forEach(([key, value]) => {
+        form.append(`metadata[${key}]`, value);
+      });
+    }
 
     return client.sendAPIRequestWithToken(basePath, {
       method: 'POST',


### PR DESCRIPTION
I've manually tested this works with the Helloworks API for a naive case.

I see the CI is failing like crazy but I can't see how this change could cause all the failure I see.