### PR TITLE
Adding delegated_authentication and getAuthenticatedLinkForStep

### DIFF
--- a/lib/endpoints/workflow-instances.js
+++ b/lib/endpoints/workflow-instances.js
@@ -88,6 +88,10 @@ const endpoint = (client) => ({
       form.append('document_delivery', 'true');
     }
 
+    if (opts.delegatedAuthentication) {
+      form.append('delegated_authentication', 'true');
+    }
+
     if (opts.metadata) {
       Object.entries(opts.metadata).forEach((key, value) => {
         form.append(`metadata[${key}]`, value);
@@ -161,6 +165,35 @@ const endpoint = (client) => ({
       return response.json();
     }).then(({ data }) => {
       return data;
+    });
+  },
+
+
+  /**
+   * Get the steps for a Workflow instance.
+   *
+   * @example
+   *
+   *   getAuthenticatedLinkForStep({
+   *     instanceId: 'Your instance ID',
+   *     step: 'signer_signer_step'
+   *   }).then((authenticatedStepURL) => {
+   *     // ...
+   *   });
+   *
+   * @param {Object} opts
+   * @param {string} opts.instanceId
+   * @param {string} opts.step
+   * @returns {Promise.String}
+   * @public
+   */
+  getAuthenticatedLinkForStep({ instanceId, step }) {
+    const endpointUrl = `${basePath}/${instanceId}/steps/${step}/delegate_auth`;
+
+    return client.sendAPIRequestWithToken(endpointUrl).then((response) => {
+      return response.json();
+    }).then(({ data }) => {
+      return data.url;
     });
   },
 

--- a/lib/helloworks.test.js
+++ b/lib/helloworks.test.js
@@ -198,6 +198,19 @@ describe('Endpoints', () => {
       });
     });
 
+    describe('#getInstanceSteps()', () => {
+
+      test('resolves with the authenticated link for the Workflow Instance step', () => {
+        return expect(
+          client.workflowInstances.getAuthenticatedLinkForStep({
+            instanceId,
+          }),
+        ).resolves.toEqual(
+          expect.any(String),
+        );
+      });
+    });
+
     describe('#getInstanceAuditTrail()', () => {
 
       test('resolves with the Workflow Instance audit trail', () => {


### PR DESCRIPTION
This just contains a couple small updates.   I updated the createInstance method to accept a delegatedAuthentication option and added a getAuthenticatedLinkForStep method for getting the authenticated URL for a workflow instance step.