### PR TITLE
Added support for document delivery type

### DIFF
--- a/lib/endpoints/workflow-instances.js
+++ b/lib/endpoints/workflow-instances.js
@@ -52,6 +52,7 @@ const endpoint = (client) => ({
    * @param {string} [opts.callbackUrl]
    * @param {string} [opts.redirectUrl]
    * @param {boolean} [opts.documentDelivery=false]
+   * @param {string} [opts.documentDeliveryType]
    * @returns {Promise.<Object>}
    * @public
    */
@@ -86,6 +87,9 @@ const endpoint = (client) => ({
 
     if (opts.documentDelivery) {
       form.append('document_delivery', 'true');
+      if (opts.documentDeliveryType) {
+        form.append('document_delivery_type', opts.documentDeliveryType);
+      }
     }
 
     if (opts.metadata) {

--- a/lib/helloworks.test.js
+++ b/lib/helloworks.test.js
@@ -98,6 +98,7 @@ describe('Endpoints', () => {
             callbackUrl: 'https://example.com/callback',
             redirectUrl: 'https://example.com/success',
             documentDelivery: true,
+            documentDeliveryType: 'link'
           }),
         ).resolves.toMatchObject({
           id: expect.stringMatching(/^[A-Za-z0-9]{16}$/),

--- a/lib/helloworks.test.js
+++ b/lib/helloworks.test.js
@@ -98,7 +98,7 @@ describe('Endpoints', () => {
             callbackUrl: 'https://example.com/callback',
             redirectUrl: 'https://example.com/success',
             documentDelivery: true,
-            documentDeliveryType: 'link'
+            documentDeliveryType: 'link',
           }),
         ).resolves.toMatchObject({
           id: expect.stringMatching(/^[A-Za-z0-9]{16}$/),


### PR DESCRIPTION
## Summary of Change

Added an additional parameter to the createInstance function, `opts.documentDeliveryType`. Per the v3.3 API documentation: 

**document_delivery_type** `string`
```
Determines the way documents will be delivered to the user upon completion of their workflow. 
It only gets applied when document_delivery is enabled. The options are 'attachment' or 'link'
```

This new parameter is only checked and included if `opts.documentDelivery` is true in accordance with the documentation. This has been tested functionally using a workflow in my company's account. 